### PR TITLE
各modelのvalidationを実装、Userモデルのテストを実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - 'db/*'
+
+RSpec/MultipleExpectations:
+  Max: 3

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem "pry-rails"
   # テストのためのもの
   # gem "factory_bot", "~> 6.2", ">= 6.2.1"
-  gem 'factory_bot_rails', '~> 6.2'
+  gem "factory_bot_rails", "~> 6.2"
   gem "faker"
   gem "rspec-rails", "~> 6.0.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,8 @@ group :development, :test do
   gem "pry-doc"
   gem "pry-rails"
   # テストのためのもの
-  gem "factory_bot", "~> 6.2", ">= 6.2.1"
+  # gem "factory_bot", "~> 6.2", ">= 6.2.1"
+  gem 'factory_bot_rails', '~> 6.2'
   gem "faker"
   gem "rspec-rails", "~> 6.0.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     faker (3.1.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
@@ -301,7 +304,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   devise_token_auth
-  factory_bot (~> 6.2, >= 6.2.1)
+  factory_bot_rails (~> 6.2)
   faker
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,7 @@
 class Article < ApplicationRecord
+  validates :title, presence:true
+  validates :body, presence: true
+
   belongs_to :user
   has_many :article_likes, dependent: :restrict_with_exception
   has_many :comment, dependent: :restrict_with_exception

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,5 @@
 class Article < ApplicationRecord
-  validates :title, presence:true
+  validates :title, presence: true
   validates :body, presence: true
 
   belongs_to :user

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -1,6 +1,6 @@
 class ArticleLike < ApplicationRecord
-  validates :user_id, presence:true
-  validates :article_id, presence:true
+  validates :user_id, presence: true
+  validates :article_id, presence: true
 
   belongs_to :article
   belongs_to :user

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -1,4 +1,7 @@
 class ArticleLike < ApplicationRecord
+  validates :user_id, presence:true
+  validates :article_id, presence:true
+
   belongs_to :article
   belongs_to :user
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
-  validates :body,presence: true
+  validates :body, presence: true
 
   belongs_to :article
   belongs_to :user

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
+  validates :body,presence: true
+
   belongs_to :article
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
+  validates :name, presence:true
+
   has_many :articles, dependent: :restrict_with_exception
   has_many :article_likes, dependent: :restrict_with_exception
   has_many :comment, dependent: :restrict_with_exception

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  validates :name, presence:true
+  validates :name, presence: true
 
   has_many :articles, dependent: :restrict_with_exception
   has_many :article_likes, dependent: :restrict_with_exception

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_09_092232) do
-
+ActiveRecord::Schema.define(version: 20_230_309_092_232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_230_309_092_232) do
+ActiveRecord::Schema.define(version: 2023_03_09_092232) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     # name {"hoge"}
     # account {"hoge"}
     # email {"hoge@hoge.com"}
-    name {Faker::Name.name}
-    sequence(:email) { |n| "#{n}_#{Faker::Internet.email}"}
-    password {Faker::Internet.password}
+    name { Faker::Name.name }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :user do
+    # name {"hoge"}
+    # account {"hoge"}
+    # email {"hoge@hoge.com"}
+    name {Faker::Name.name}
+    sequence(:email) { |n| "#{n}_#{Faker::Internet.email}"}
+    password {Faker::Internet.password}
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
   # pending "add some examples to (or delete) #{__FILE__}"
@@ -11,12 +11,11 @@ RSpec.describe User, type: :model do
   end
 
   context "nameが空白の時" do
-    fit "ユーザー作成に失敗" do
+    it "ユーザー作成に失敗" do
       # user = User.new(name: "foo", email: "foo@foo.com")
-      user = build(:user,{name: ""})
-      expect(user).to be_invalid
-      binding.pry
-      expect(user.errors.errors[0].attribute).to eq :name
+      user = build(:user, { name: "" })
+      # expect(user).to be_invalid
+      # expect(user.errors.errors[0].attribute).to eq :name
       expect(user.errors.errors[0].type).to eq :blank
     end
   end
@@ -24,9 +23,9 @@ RSpec.describe User, type: :model do
   context "passwordが8文字以下" do
     it "ユーザー作成に失敗" do
       # user = User.new(name: "foo", email: "foo@foo.com")
-      user = build(:user,{password: "bla32"})
-      expect(user).to be_invalid
-      expect(user.errors.errors[0].attribute).to eq :password
+      user = build(:user, { password: "bla32" })
+      # expect(user).to be_invalid
+      # expect(user.errors.errors[0].attribute).to eq :password
       expect(user.errors.errors[0].type).to eq :too_short
       # expect(user.errors.details[:account][0][:error]).to eq :blank
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  # pending "add some examples to (or delete) #{__FILE__}"
+  context "全てが指定されているとき" do
+    it "ユーザーが作られる" do
+      # user = User.new(name: "foo",account: "foo", email: "foo@foo.com")
+      user = build(:user)
+      expect(user).to be_valid
+    end
+  end
+
+  context "nameが空白の時" do
+    fit "ユーザー作成に失敗" do
+      # user = User.new(name: "foo", email: "foo@foo.com")
+      user = build(:user,{name: ""})
+      expect(user).to be_invalid
+      binding.pry
+      expect(user.errors.errors[0].attribute).to eq :name
+      expect(user.errors.errors[0].type).to eq :blank
+    end
+  end
+
+  context "passwordが8文字以下" do
+    it "ユーザー作成に失敗" do
+      # user = User.new(name: "foo", email: "foo@foo.com")
+      user = build(:user,{password: "bla32"})
+      expect(user).to be_invalid
+      expect(user.errors.errors[0].attribute).to eq :password
+      expect(user.errors.errors[0].type).to eq :too_short
+      # expect(user.errors.details[:account][0][:error]).to eq :blank
+    end
+  end
+
+  # context "acoountが存在していない時" do
+  #   it "ユーザーが作られる" do
+  #   end
+  # end
+
+  # context "accountが存在しているとき" do
+  #   before { create(:user,{name: "bar",account: "foo", email: "bar@foo.com"}) }
+  #   it "ユーザー作成に失敗" do
+  #     # User.create!(name: "bar",account: "foo", email: "bar@foo.com")
+  #     # binding.pry
+  #     user = build(:user,{name: "foo",account: "foo", email: "foo@foo.com"})
+  #     expect(user).to be_invalid
+  #     expect(user.errors.details[:account][0][:error]).to eq :taken
+  #   end
+  # end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe User, type: :model do
     it "ユーザー作成に失敗" do
       # user = User.new(name: "foo", email: "foo@foo.com")
       user = build(:user, { name: "" })
-      # expect(user).to be_invalid
-      # expect(user.errors.errors[0].attribute).to eq :name
+      expect(user).to be_invalid
+      expect(user.errors.errors[0].attribute).to eq :name
       expect(user.errors.errors[0].type).to eq :blank
     end
   end
@@ -24,8 +24,8 @@ RSpec.describe User, type: :model do
     it "ユーザー作成に失敗" do
       # user = User.new(name: "foo", email: "foo@foo.com")
       user = build(:user, { password: "bla32" })
-      # expect(user).to be_invalid
-      # expect(user.errors.errors[0].attribute).to eq :password
+      expect(user).to be_invalid
+      expect(user.errors.errors[0].attribute).to eq :password
       expect(user.errors.errors[0].type).to eq :too_short
       # expect(user.errors.details[:account][0][:error]).to eq :blank
     end


### PR DESCRIPTION
## モデルのvalidationを実装
・Userモデル
passwordとemailはdivise-token-authの独自のものがあるのでvalidationはスルー
nameは空白を許容しないように
・Articleモデル
titleは空白を許容しないように
bodyは空白を許容しないように
・Commentモデル
bodyは空白を許容しないように
・ArticleLikeモデル
user_id、article_idどちらも空白を許容しない

## Userモデルのテストを実装
正常系
・name、email、password全てが正しく指定されていればUserのレコードが作成される
異常系
・nameが空白の時、エラーが起きUserのレコードが作成されない
・psswordが8文字以下の時、エラーが起きUserのレコードが作成されない
