### PR TITLE
userモデルのテストを追加、新規にarticleモデルのテストを実装

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, password_length: 8..128
   include DeviseTokenAuth::Concerns::User
 
   validates :name, presence: true

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :article do
+    # name {"hoge"}
+    # account {"hoge"}
+    # email {"hoge@hoge.com"}
+    title { Faker::Lorem.sentence }
+    body { Faker::Lorem.paragraphs }
+    user
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Article, type: :model do
+  # pending "add some examples to (or delete) #{__FILE__}"
+  context "全てが指定されているとき" do
+    it "記事が作られる" do
+      article = build(:article)
+      expect(article).to be_valid
+    end
+  end
+
+  context "titleが空白の時" do
+    it "記事の作成に失敗" do
+      # user = User.new(name: "foo", email: "foo@foo.com")
+      article = build(:article, { title: "" })
+      expect(article).to be_invalid
+      expect(article.errors.errors[0].attribute).to eq :title
+      expect(article.errors.errors[0].type).to eq :blank
+    end
+  end
+
+  context "body空白の時" do
+    it "記事の作成に失敗" do
+      # user = User.new(name: "foo", email: "foo@foo.com")
+      article = build(:article, { body: "" })
+      expect(article).to be_invalid
+      expect(article.errors.errors[0].attribute).to eq :body
+      expect(article.errors.errors[0].type).to eq :blank
+    end
+  end
+
+  # context "acoountが存在していない時" do
+  #   it "ユーザーが作られる" do
+  #   end
+  # end
+
+  # context "accountが存在しているとき" do
+  #   before { create(:user,{name: "bar",account: "foo", email: "bar@foo.com"}) }
+  #   it "ユーザー作成に失敗" do
+  #     # User.create!(name: "bar",account: "foo", email: "bar@foo.com")
+  #     # binding.pry
+  #     user = build(:user,{name: "foo",account: "foo", email: "foo@foo.com"})
+  #     expect(user).to be_invalid
+  #     expect(user.errors.details[:account][0][:error]).to eq :taken
+  #   end
+  # end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,26 @@ RSpec.describe User, type: :model do
     end
   end
 
+  context "emailが空白の時" do
+    it "ユーザー作成に失敗" do
+      # user = User.new(name: "foo", email: "foo@foo.com")
+      user = build(:user, { email: "" })
+      expect(user).to be_invalid
+      expect(user.errors.errors[0].attribute).to eq :email
+      expect(user.errors.errors[0].type).to eq :blank
+    end
+  end
+
+  context "password空白の時" do
+    it "ユーザー作成に失敗" do
+      # user = User.new(name: "foo", email: "foo@foo.com")
+      user = build(:user, { password: "" })
+      expect(user).to be_invalid
+      expect(user.errors.errors[0].attribute).to eq :password
+      expect(user.errors.errors[0].type).to eq :blank
+    end
+  end
+
   context "nameが空白の時" do
     it "ユーザー作成に失敗" do
       # user = User.new(name: "foo", email: "foo@foo.com")
@@ -23,7 +43,7 @@ RSpec.describe User, type: :model do
   context "passwordが8文字以下" do
     it "ユーザー作成に失敗" do
       # user = User.new(name: "foo", email: "foo@foo.com")
-      user = build(:user, { password: "bla32" })
+      user = build(:user, { password: "bla322r" })
       expect(user).to be_invalid
       expect(user.errors.errors[0].attribute).to eq :password
       expect(user.errors.errors[0].type).to eq :too_short


### PR DESCRIPTION
## Userモデルのテストを追加
emailとpasswordも空白の場合にエラーがおこりユーザーが作成されないテストを追加

## Articleモデルのテストを追加
・titleとbodyに空白を認めないテストを追加
・ユーザーのレコード先に作られないとエラーを吐くため、associationの記述
->モデル名とassociationの名称が一緒のため、userのみ記載