### PR TITLE
endpointの設定(/api/v1)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
+      resources :articles, :comment, :article_likes
+    end
+  end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
・ /api/v1 に設定した目的
API 用の endpoint であることが明確になり、API のバージョン管理ができるようになる。

参考url
[railsガイド](https://railsguides.jp/routing.html#%E3%82%B3%E3%83%B3%E3%83%88%E3%83%AD%E3%83%BC%E3%83%A9%E3%81%AE%E5%90%8D%E5%89%8D%E7%A9%BA%E9%96%93%E3%81%A8%E3%83%AB%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0)