### PR TITLE
updateメソッドの実装およびテストを作成

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -16,6 +16,15 @@ module Api
         render json: article, serializer: Api::V1::ArticleSerializer
       end
 
+      def update
+        article = Article.find(params[:id])
+        # current_user.articles.create!(article_params)
+        binding.pry
+        article.update!(article_params)
+        binding.pry
+        render json: article, serializer: Api::V1::ArticleSerializer
+      end
+
       private
 
         # Storong Parameter

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -17,11 +17,9 @@ module Api
       end
 
       def update
-        article = Article.find(params[:id])
+        article = current_user.articles.find(params[:id])
         # current_user.articles.create!(article_params)
-        binding.pry
         article.update!(article_params)
-        binding.pry
         render json: article, serializer: Api::V1::ArticleSerializer
       end
 

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -70,4 +70,26 @@ RSpec.describe "Article", type: :request do
       end
     end
   end
+
+  describe "PATCH /articles/:id" do
+    subject { patch(api_v1_article_path(article_id), params: { article: article_params }) }
+
+    context "適切なパラメータをもとに記事が更新される" do
+      let(:article) { create(:article) }
+      let(:article_id) { article.id }
+      let(:article_params) { { title: Faker::Lorem.sentence } }
+      # let(:user) { create(:user) }
+
+      # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(user) }
+
+      fit "現在のユーザをもとに記事が作成できる" do
+        # post :create, params: { article: { title: "Test Article", body: "Lorem ipsum dolor sit amet" } }
+        #タイトルだけ変える想定
+        expect{ subject }.to change {article.reload.title}.from(article.title).to(article_params[:title]) &
+                         not_change {article.reload.body} &
+                         not_change {article.reload.created_at}
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Article", type: :request do
       let(:article) { create(:article, user: user) }
       let(:article_id) { article.id }
 
-      fit "記事が更新できる" do
+      it "記事が更新できる" do
         # post :create, params: { article: { title: "Test Article", body: "Lorem ipsum dolor sit amet" } }
         # タイトルだけ変える想定
         expect { subject }.to change { article.reload.title }.from(article.title).to(article_params[:title]) &
@@ -96,7 +96,7 @@ RSpec.describe "Article", type: :request do
     context "自分が所持していない記事のレコードを更新しようとするとき" do
       let(:article_id) { article.id }
       let!(:article) { create(:article, user: other_user) }
-      fit "記事が更新できない" do
+      it "記事が更新できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,4 +89,5 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+  RSpec::Matchers.define_negated_matcher :not_change, :change
 end


### PR DESCRIPTION
createのスタブをもとにupdateメソッドを作成

詰まったとこと
記事作成時のユーザー指定がうまくできておらず、メソッド側のcurrent_userと更新予定のユーザーが違っていてエラーを吐いていたところ。