### PR TITLE
devise-token-authを使用したtoken認証でのユーザー登録機能の実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
   Exclude:
   - vendor/bundle/**/*
   - db/migrate/*
+  - node_modules/node-sass
   TargetRubyVersion: 2.7
 
 Metrics/BlockLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,11 +8,16 @@ inherit_from:
 
 AllCops:
   # SuggestExtensions: false
+  TargetRubyVersion: 3.1.1
   Exclude:
-  - vendor/bundle/**/*
-  - db/migrate/*
-  - node_modules/node-sass
-  TargetRubyVersion: 2.7
+    - "node_modules/**/*" # rubocop config/default.yml
+    - "vendor/**/*" # rubocop config/default.yml
+    - "db/schema.rb"
+    - "bin/bundle"
+    - db/migrate/*
+  # Exclude:
+  # - vendor/bundle/**/*
+
 
 Metrics/BlockLength:
   Exclude:
@@ -25,4 +30,6 @@ RSpec/MultipleExpectations:
   Max: 10
 #一旦指摘無視して実装進めたいため記述
 RSpec/AnyInstance:
+  Enabled: false
+Style/GlobalVars:
   Enabled: false

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -4,14 +4,14 @@ module Api
       class RegistrationsController < DeviseTokenAuth::RegistrationsController
         private
 
-        def sign_up_params
-          params.require(:user).permit(:name, :email, :password, :password_confirmation)
-          # params.require(:registration).permit(:email, :password)
-        end
+          def sign_up_params
+            params.require(:user).permit(:name, :email, :password, :password_confirmation)
+            # params.require(:registration).permit(:email, :password)
+          end
 
-        def account_update_params
-          params.require(:user).permit(:name, :email)
-        end
+          def account_update_params
+            params.require(:user).permit(:name, :email)
+          end
       end
     end
   end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    module Auth
+      class RegistrationsController < DeviseTokenAuth::RegistrationsController
+        private
+
+        def sign_up_params
+          params.require(:user).permit(:name, :email, :password, :password_confirmation)
+          # params.require(:registration).permit(:email, :password)
+        end
+
+        def account_update_params
+          params.require(:user).permit(:name, :email)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class BaseApiController < ApplicationController
+      include DeviseTokenAuth::Concerns::SetUserByToken
+
       def current_user
         User.first
       end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V1
     class BaseApiController < ApplicationController
-      include DeviseTokenAuth::Concerns::SetUserByToken
-
       def current_user
         User.first
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,8 @@ module WonderfulEditor
                        request_specs: true
     end
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
     # protect_from_forgeryの設定
-    config.action_controller.default_protect_from_forgery = false
+    # config.action_controller.default_protect_from_forgery = false
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,5 +47,8 @@ module WonderfulEditor
                        request_specs: true
     end
     config.api_only = true
+    # protect_from_forgeryの設定
+    config.action_controller.default_protect_from_forgery = false
+
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,5 @@ module WonderfulEditor
     config.api_only = true
     # protect_from_forgeryの設定
     config.action_controller.default_protect_from_forgery = false
-
   end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,6 +42,12 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
+  config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type",
+                           authorization: "authorization" }
   # config.headers_names = {:'access-token' => 'access-token',
   #                        :'client' => 'client',
   #                        :'expiry' => 'expiry',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth",controllers: {
+        registrations: 'api/v1/auth/registrations'
+      }
       resources :articles
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth",controllers: {
-        registrations: 'api/v1/auth/registrations'
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations",
       }
       resources :articles
     end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Article", type: :request do
     before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(user) }
 
     context "自分が所持している記事のレコードを更新するとき" do
-      let(:article) { create(:article, user: user) }
+      let(:article) { create(:article, user:) }
       let(:article_id) { article.id }
 
       it "記事が更新できる" do
@@ -110,7 +110,7 @@ RSpec.describe "Article", type: :request do
     before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(user) }
 
     context "自分が所持している記事を削除しようとするとき" do
-      let(:article) { create(:article, user: user) }
+      let(:article) { create(:article, user:) }
       let(:article_id) { article.id }
       it "任意の記事を削除できる" do
         expect { subject }.to change { Article.count }.by(0)

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "GET /index" do


### PR DESCRIPTION
## 概要
 ユーザー登録機能を作成するにあたり今回はtoken認証を使用したユーザーのCRUD機能を作成したい。
そのため、devise-token-authを使用して、token認証の実現をしたい。

## 変更内容:
### rubocop.yml
->rubocopを通すときにでパッケージなどで引っ掛かることをなくすために記述を追記。

### app/controllers/api/v1/auth/registrations_controller.rb
->`rails g controller api/v1/auth/registrations`でdevise-token-authを使用するためauthディレクトリ配下にコントローラを作成。

def sign_up_params ->登録機能のストロングパラメータ
def account_update_params->更新機能の登録機能のストロングパラメータ(一緒に作成しときました。)

### app/controllers/application_controller.rb
->CSRF 対策を OFF にする記述をしています。
意図としては、初期実装においてCRUD処理の確認をしやすくするためです。

### config/application.rb
->falshメッセージを有効にしています。

### config/initializers/devise_token_auth.rb
->ヘッダー情報の更新をfalseにしております。
同じトークンを複数のリクエストで使用することができ、トークン認証において、同じトークンを使って複数のリクエストを連続して送信する場合に便利であること。トークンが変更されると、サーバー側での認証が失敗する可能性があるため、連続したリクエストを送信する際には同じトークンを使用することが求められることもあるため。

トークンの期限は2週間で設定してます。

### config/routes.rb
->作成したapp/controllers/api/v1/auth/registrations_controller.rbへルートを通しています。

返すヘッダー情報をコメントアウトを外して有効にしてます。

### spec/requests/api/v1/articles_spec.rb
->rubocopの修正でarticleの方も変更されており、その変更でございます

### spec/requests/api/v1/auth/registrations_spec.rb
->gコマンドで作られた自動的なファイルです。


## 参考にしたもの:
chatgpt
https://devise-token-auth.gitbook.io/devise-token-auth/
https://qiita.com/tomokazu0112/items/5fdd6a51a84c520c45b5#%E5%88%9D%E6%9C%9F%E8%A8%AD%E5%AE%9A