### PR TITLE
新規登録機能の正常系、異常系テストの実装

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -48,6 +48,7 @@ DeviseTokenAuth.setup do |config|
                            uid: "uid",
                            'token-type': "token-type",
                            authorization: "authorization" }
+
   # config.headers_names = {:'access-token' => 'access-token',
   #                        :'client' => 'client',
   #                        :'expiry' => 'expiry',

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -6,26 +6,71 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   end
 
   describe "POST /api/v1/users" do
-    subject { post(api_v1_user_registration_path,params: user_params) }
-    context "適切なパラメータをもとにユーザが作成される" do
-      let(:user_params) { {user: attributes_for(:user)} }
-      fit "新規ユーザーが作られる" do
+    subject { post(api_v1_user_registration_path, params: user_params) }
+
+    context "適切なパラメータが送信されたとき" do
+      let(:user_params) { { user: attributes_for(:user) } }
+      it "新規ユーザーが作られる" do
         expect { subject }.to change { User.count }.by(1)
         res = JSON.parse(response.body)
-        # binding.pry
         expect(res["data"]["name"]).to eq user_params[:user][:name]
         expect(res["data"]["email"]).to eq user_params[:user][:email]
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
+
+      it "想定したヘッダー情報が返ってくる" do
+        subject
+        expected_headers = ["token-type", "access-token", "client", "uid", "expiry"]
+        expected_headers.each do |header_key|
+          expect(response.header[header_key]).to be_present
+        end
+      end
+
+      #   expect(response.header["token-type"]).to be_present
+      #   expect(response.header["access-token"]).to be_present
+      #   expect(response.header["client"]).to be_present
+      #   expect(response.header["uid"]).to be_present
+      #   expect(response.header["expiry"]).to be_present
+      #   expect(response.header).to have_http_status(:ok)
+      # end
     end
 
-    context "不適切なパラメータが送れた時はエラーが起こりユーザが作成されない" do
+    context "不適切なパラメータが送れた時" do
       let(:user_params) { attributes_for(:user) }
-      fit "エラーが返ってくる" do
-        binding.pry
+      it "エラーが返ってくる" do
+        # binding.pry
         expect { subject }.to raise_error ActionController::ParameterMissing
       end
     end
 
+    context "nameがない時" do
+      let(:user_params) { { user: attributes_for(:user, name: nil) } }
+      # let(:user_params) { attributes_for(:user,name: nil) }
+      it "エラーが返ってくる" do
+        subject
+        # expect { subject }.to raise_error ActionController::ParameterMissing
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "emailがない時" do
+      let(:user_params) { { user: attributes_for(:user, email: nil) } }
+      # let(:user_params) { attributes_for(:user,name: nil) }
+      it "エラーが返ってくる" do
+        subject
+        # expect { subject }.to raise_error ActionController::ParameterMissing
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "passwordがない時" do
+      let(:user_params) { { user: attributes_for(:user, password: nil) } }
+      # let(:user_params) { attributes_for(:user,name: nil) }
+      it "エラーが返ってくる" do
+        subject
+        # expect { subject }.to raise_error ActionController::ParameterMissing
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -4,4 +4,28 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "GET /index" do
     pending "add some examples (or delete) #{__FILE__}"
   end
+
+  describe "POST /api/v1/users" do
+    subject { post(api_v1_user_registration_path,params: user_params) }
+    context "適切なパラメータをもとにユーザが作成される" do
+      let(:user_params) { {user: attributes_for(:user)} }
+      fit "新規ユーザーが作られる" do
+        expect { subject }.to change { User.count }.by(1)
+        res = JSON.parse(response.body)
+        # binding.pry
+        expect(res["data"]["name"]).to eq user_params[:user][:name]
+        expect(res["data"]["email"]).to eq user_params[:user][:email]
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "不適切なパラメータが送れた時はエラーが起こりユーザが作成されない" do
+      let(:user_params) { attributes_for(:user) }
+      fit "エラーが返ってくる" do
+        binding.pry
+        expect { subject }.to raise_error ActionController::ParameterMissing
+      end
+    end
+
+  end
 end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
 
       it "想定したヘッダー情報が返ってくる" do
         subject
-        expected_headers = ["token-type", "access-token", "client", "uid", "expiry"]
+        expected_headers = ["token-type", "access-token", "client", "uid", "expiry", "authorization"]
         expected_headers.each do |header_key|
           expect(response.header[header_key]).to be_present
         end


### PR DESCRIPTION
## 概要: 
ユーザー登録機能の実装が終了したため、意図した動きになっているか確認のため、正常系、異常系テストの実装をしました。

## 作成内容: 

### 正常系テスト
正しいフォーマットのパラメータの場合
・ユーザーが作られる
httpステータスが正しいこと、そして作られたユーザー情報が取得できることを確認しています。

・意図したheader情報が返ってくる
前提として、devise-token-authでのtoken認証には以下のヘッダー情報を含める必要あります。

"access-token": "トークンの値",
"client": "クライアントIDの値",
"uid": "ユーザーのUIDの値",
"expiry": "トークンの有効期限の値"

また、/config/initializer/devise_token_auth.rbには以下の記述をしており、こちらのヘッダー情報が含まれることを確認したいため、以下の項目を確認する記述をしています。
```
config.headers_names = {
                          'access-token': "access-token",
                           client: "client",
                           expiry: "expiry",
                           uid: "uid",
                           'token-type': "token-type",
                           authorization: "authorization" }
```

### 異常系テスト
・パラメータの形式が異常の場合
パラメータの形式が以上の場合、ユーザー作成がされないこと。
意図したエラーが返ってくることを確認しています。

・必要な情報がない場合
httpステータスが422処理できないエンティティを表す、Unprocessable Entityで確認しています。
