### PR TITLE
ログイン機能のテストの実装異常系テストまで

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,9 +22,10 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - 'db/*'
-Metrics/ExampleLength:
-  Exclude:
-    - 'spec/requests/api/v1/*'
+# Metrics/ExampleLength:
+#   Exclude:
+#     - 'spec/requests/api/v1/*'
+#     - 'spec/requests/api/v1/**/*'
 
 RSpec/MultipleExpectations:
   Max: 10

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -20,7 +20,7 @@ RSpec/EmptyLineAfterFinalLet:
 # feature spec は exclude でも良いかもしれない。
 # ヒアドキュメント使うと一瞬で超えるので disable も検討。
 RSpec/ExampleLength:
-  Max: 8
+  Max: 10
 
 # block の方がテスト対象が
 # * `{}` の前後のスペースと相まって目立つ

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+
+  describe "POST /api/v1/users/sing_in" do
+    subject { post(api_v1_user_session_path, params: user_params) }
+
+    context "適切なパラメータが送信されたとき" do
+      # 登録してあるユーザーのemail,passwordを送信したらログインができる
+      # ログインしたらtoken情報が返ってくる
+      # パラメータが違かったらエラーが起きる
+      # パラメータがない場合エラーが起きる
+      let(:user) { create(:user) }
+      let(:user_params) { {  email: user.email, password: user.password } }
+      it "ログインができる" do
+        subject
+        # res = JSON.parse(response.body)
+        # expect(res["data"]["name"]).to eq user_params[:user][:name]
+        # expect(res["data"]["email"]).to eq user_params[:user][:email]
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "想定したヘッダー情報が返ってくる" do
+        subject
+        expected_headers = ["token-type", "access-token", "client", "uid", "expiry", "authorization"]
+        expected_headers.each do |header_key|
+          expect(response.header[header_key]).to be_present
+        end
+      end
+
+      #   expect(response.header["token-type"]).to be_present
+      #   expect(response.header["access-token"]).to be_present
+      #   expect(response.header["client"]).to be_present
+      #   expect(response.header["uid"]).to be_present
+      #   expect(response.header["expiry"]).to be_present
+      #   expect(response.header).to have_http_status(:ok)
+      # end
+    end
+
+    context "余計なnameがある時" do
+      let(:user) { create(:user) }
+      let(:user_params) { attributes_for(:user) }
+      it "余計なnameがある時エラーが返ってくる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to be_present
+      end
+    end
+
+    context "passwordがない時" do
+      let(:user) { create(:user) }
+      let(:user_params) { {  email: user.email, password: nil } }
+      # let(:user_params) { attributes_for(:user,name: nil) }
+      it "エラーが返ってくる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to be_present
+        # subject
+        # # expect { subject }.to raise_error ActionController::ParameterMissing
+        # expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "emailがない時" do
+      let(:user) { create(:user) }
+      let(:user_params) { {  email: nil, password: user.password } }
+      # let(:user_params) { attributes_for(:user,name: nil) }
+      it "エラーが返ってくる" do
+        expect { subject }.to raise_error NoMethodError
+      end
+    end
+
+    context "passwordが違う時" do
+      let(:user) { create(:user) }
+      let(:user_params) { {  email: user.email, password: "mineraruwater" } }
+      # let(:user_params) { attributes_for(:user,name: nil) }
+      it "エラーが返ってくる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to be_present
+        # subject
+        # # expect { subject }.to raise_error ActionController::ParameterMissing
+        # expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "emailが違う時" do
+      let(:user) { create(:user) }
+      let(:user_params) { {  email: "mineraruwater@mineraru.com", password: user.password } }
+      # let(:user_params) { attributes_for(:user,name: nil) }
+      it "エラーが返ってくる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to be_present
+        # subject
+        # # expect { subject }.to raise_error ActionController::ParameterMissing
+        # expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
ログイン機能のテストの実装を行いました。
devise-token-authのデフォルト機能ですでに機能は使えるためテストのみの実装でございます。

## 内容
・spec/requests/api/v1/auth/sessions_spec.rb

以下のことをテストで実装したくコードを書きました。

```
# 登録してあるユーザーのemail,passwordを送信したらログインができる
# ログインしたらtoken情報が返ってくる
# パラメータが違かったらエラーが起きる
# パラメータがない場合エラーが起きる
```
