### PR TITLE
DeviseTokenAuthからの継承、およびダミーメソッドを削除しdivise_token_authをしようしたメソッドに変更

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class ArticlesController < BaseApiController
-      skip_before_action :authenticate_api_v1_user! , only: %i[ index show]
+      skip_before_action :authenticate_api_v1_user!, only: %i[index show]
 
       def index
         articles = Article.order(updated_at: :desc)

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class ArticlesController < BaseApiController
+      skip_before_action :authenticate_api_v1_user! , only: %i[ index show]
+
       def index
         articles = Article.order(updated_at: :desc)
         render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
@@ -12,19 +14,19 @@ module Api
       end
 
       def create
-        article = current_user.articles.create!(article_params)
+        article = current_api_v1_user.articles.create!(article_params)
         render json: article, serializer: Api::V1::ArticleSerializer
       end
 
       def update
-        article = current_user.articles.find(params[:id])
+        article = current_api_v1_user.articles.find(params[:id])
         # current_user.articles.create!(article_params)
         article.update!(article_params)
         render json: article, serializer: Api::V1::ArticleSerializer
       end
 
       def destroy
-        article = current_user.articles.find(params[:id])
+        article = current_api_v1_user.articles.find(params[:id])
         article.destroy!
         render json: article, serializer: Api::V1::ArticleSerializer
       end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -2,7 +2,6 @@ module Api
   module V1
     module Auth
       class RegistrationsController < DeviseTokenAuth::RegistrationsController
-
         private
 
           def sign_up_params

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V1
     module Auth
       class RegistrationsController < DeviseTokenAuth::RegistrationsController
+        skip_before_action :authenticate_api_v1_user! , only: %i[ sign_up_params]
+
         private
 
           def sign_up_params

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     module Auth
       class RegistrationsController < DeviseTokenAuth::RegistrationsController
-        skip_before_action :authenticate_api_v1_user! , only: %i[ sign_up_params]
+        skip_before_action :authenticate_api_v1_user!, only: %i[sign_up_params]
 
         private
 

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -2,7 +2,6 @@ module Api
   module V1
     module Auth
       class RegistrationsController < DeviseTokenAuth::RegistrationsController
-        skip_before_action :authenticate_api_v1_user!, only: %i[sign_up_params]
 
         private
 

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,9 +1,9 @@
 module Api
   module V1
     class BaseApiController < ApplicationController
-      def current_user
-        User.first
-      end
+      include DeviseTokenAuth::Concerns::SetUserByToken
+
+      before_action :authenticate_api_v1_user!
     end
   end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Article", type: :request do
     let!(:article2) { create(:article, updated_at: 2.days.ago) }
     let!(:article3) { create(:article, title: "一番最初") }
 
-    fit "記事の一覧を取得できる" do
+    it "記事の一覧を取得できる" do
       p(subject)
       res = JSON.parse(response.body)
       # res.length = 3
@@ -34,7 +34,7 @@ RSpec.describe "Article", type: :request do
     context "指定したidのデータが返ってくること(200)" do
       let(:article) { create(:article) }
       let(:article_id) { article.id }
-      fit "記事詳細を取得" do
+      it "記事詳細を取得" do
         p(subject)
         res = JSON.parse(response.body)
         expect(res.keys).to eq ["id", "title", "body", "updated_at", "user"]
@@ -56,20 +56,21 @@ RSpec.describe "Article", type: :request do
   end
 
   describe "POST /articles/" do
-    subject { post(api_v1_articles_path, params: { article: article_params } ,headers:) }
+    subject { post(api_v1_articles_path, params: { article: article_params }, headers:) }
+
     let(:user) { create(:user) }
     let(:article_params) { attributes_for(:article) }
 
     context "ログインユーザーの時、適切なパラメータをもとに記事が作成される" do
       let!(:headers) { user.create_new_auth_token }
       # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_api_v1_user).and_return(user) }
-      fit "現在のユーザをもとに記事が作成できる" do
+      it "現在のユーザをもとに記事が作成できる" do
         subject
         expect(Article.last.user_id).to eq(user.id)
         expect(response).to have_http_status(:ok)
       end
 
-      fit "想定したヘッダー情報が返ってくる" do
+      it "想定したヘッダー情報が返ってくる" do
         subject
         expected_headers = ["token-type", "access-token", "client", "uid", "expiry", "authorization"]
         expected_headers.each do |header_key|
@@ -78,7 +79,17 @@ RSpec.describe "Article", type: :request do
       end
     end
 
-    context "token情報が違う時時、記事が作成されない" do
+    context "tokenを渡していない時、記事が作成されない" do
+      fit "エラーが起きる" do
+        subject
+        binding.pry
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:unauthorized)
+        expect(res["errors"][0]).to eq "You need to sign in or sign up before continuing."
+      end
+    end
+
+    context "token情報が違う時、記事が作成されない" do
       let!(:headers) {
         { "access-token" => "1111",
           "token-type" => "kbndk",
@@ -87,18 +98,17 @@ RSpec.describe "Article", type: :request do
           "uid" => "222",
           "authorization" => "" }
       }
-      fit "エラーが起きる" do
+      it "エラーが起きる" do
         subject
-        binding.pry
         res = JSON.parse(response.body)
-        expect(response).to have_http_status(401)
+        expect(response).to have_http_status(:unauthorized)
         expect(res["errors"][0]).to eq "You need to sign in or sign up before continuing."
       end
     end
   end
 
   describe "PATCH /articles/:id" do
-    subject { patch(api_v1_article_path(article_id), params: { article: article_params } ,headers:) }
+    subject { patch(api_v1_article_path(article_id), params: { article: article_params }, headers:) }
 
     let(:article_params) { { title: Faker::Lorem.sentence } }
     let(:other_user) { create(:user) }
@@ -110,7 +120,7 @@ RSpec.describe "Article", type: :request do
       let(:article) { create(:article, user:) }
       let(:article_id) { article.id }
 
-      fit "記事が更新できる" do
+      it "記事が更新できる" do
         # post :create, params: { article: { title: "Test Article", body: "Lorem ipsum dolor sit amet" } }
         # タイトルだけ変える想定
         expect { subject }.to change { article.reload.title }.from(article.title).to(article_params[:title]) &
@@ -119,7 +129,7 @@ RSpec.describe "Article", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      fit "想定したヘッダー情報が返ってくる" do
+      it "想定したヘッダー情報が返ってくる" do
         subject
         expected_headers = ["token-type", "access-token", "client", "uid", "expiry", "authorization"]
         expected_headers.each do |header_key|
@@ -128,7 +138,7 @@ RSpec.describe "Article", type: :request do
       end
     end
 
-    context "token情報が違う時時、記事が作成されない" do
+    context "token情報が違う時、記事が作成されない" do
       let(:article) { create(:article, user:) }
       let(:article_id) { article.id }
       let!(:headers) {
@@ -141,9 +151,9 @@ RSpec.describe "Article", type: :request do
       }
       fit "エラーが起きる" do
         subject
-        binding.pry
         res = JSON.parse(response.body)
-        expect(response).to have_http_status(401)
+        binding.pry
+        expect(response).to have_http_status(:unauthorized)
         expect(res["errors"][0]).to eq "You need to sign in or sign up before continuing."
       end
     end
@@ -152,14 +162,14 @@ RSpec.describe "Article", type: :request do
       let(:article_id) { article.id }
       let!(:article) { create(:article, user: other_user) }
       let!(:headers) { user.create_new_auth_token }
-      fit "記事が更新できない" do
+      it "記事が更新できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article_id),headers:) }
+    subject { delete(api_v1_article_path(article_id), headers:) }
 
     let(:other_user) { create(:user) }
     let(:user) { create(:user) }
@@ -169,11 +179,12 @@ RSpec.describe "Article", type: :request do
     context "自分が所持している記事を削除しようとするとき" do
       let(:article) { create(:article, user:) }
       let(:article_id) { article.id }
-      fit "任意の記事を削除できる" do
+      it "任意の記事を削除できる" do
         expect { subject }.to change { Article.count }.by(0)
         expect(response).to have_http_status(:ok)
       end
-      fit "想定したヘッダー情報が返ってくる" do
+
+      it "想定したヘッダー情報が返ってくる" do
         subject
         expected_headers = ["token-type", "access-token", "client", "uid", "expiry", "authorization"]
         expected_headers.each do |header_key|
@@ -185,7 +196,7 @@ RSpec.describe "Article", type: :request do
     context "自分が所持していない記事を削除しようとするとき" do
       let(:article) { create(:article, user: other_user) }
       let(:article_id) { article.id }
-      fit "任意の記事を削除できない" do
+      it "任意の記事を削除できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end


### PR DESCRIPTION
## 概要: 
current_userをダミーメソッドで実装していたため、そこを修正
記事作成、更新、削除など継承のメソッドをもとにtoken認証でログインを確認し実行できるようcontorllerとテストを変更

## 変更内容: 
### app/controllers/api/v1/articles_controller.rb
index,showメソッドはログインが必要ないので'before_action'の'authenticate_api_v1_user!'をスキップしています。

 ### app/controllers/api/v1/auth/registrations_controller.rb
同様に登録時はまだログインはしていないのでスキップしています。

### app/controllers/api/v1/base_api_controller.rb
ダミーメソッドからdivise_token_authの機能を継承し、BaseApiControllerでしようすることができるようにしております。

### spec/requests/api/v1/articles_spec.rb
作成、更新、削除の時にheader情報を送信するようにしてtoken認証をしております。

tokenを送っていない時、tokne情報が間違っている時の異常系テストをしております。

