### PR TITLE
下書き機能の追加とmodelテストの追加

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -15,7 +15,7 @@ module Api
 
       def create
         status = params[:status] || :draft # デフォルトはdraft
-        article_params.merge!(status: status)
+        article_params.merge!(status:)
 
         article = current_api_v1_user.articles.create!(article_params)
         render json: article, serializer: Api::V1::ArticleSerializer

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -14,9 +14,6 @@ module Api
       end
 
       def create
-        status = params[:status] || :draft # デフォルトはdraft
-        article_params.merge!(status:)
-
         article = current_api_v1_user.articles.create!(article_params)
         render json: article, serializer: Api::V1::ArticleSerializer
       end
@@ -38,7 +35,7 @@ module Api
 
         # Storong Parameter
         def article_params
-          params.require(:article).permit(:title, :body).merge(status: params[:status] || :draft)
+          params.require(:article).permit(:title, :body)
         end
     end
   end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -14,6 +14,9 @@ module Api
       end
 
       def create
+        status = params[:status] || :draft # デフォルトはdraft
+        article_params.merge!(status: status)
+
         article = current_api_v1_user.articles.create!(article_params)
         render json: article, serializer: Api::V1::ArticleSerializer
       end
@@ -35,7 +38,7 @@ module Api
 
         # Storong Parameter
         def article_params
-          params.require(:article).permit(:title, :body)
+          params.require(:article).permit(:title, :body).merge(status: params[:status] || :draft)
         end
     end
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,4 +5,6 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :article_likes, dependent: :restrict_with_exception
   has_many :comment, dependent: :restrict_with_exception
+
+  enum status: { draft: 0, published: 1 }
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at,:status
+  attributes :id, :title, :body, :updated_at, :status
   # binding.pry
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at,:status
   # binding.pry
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/db/migrate/20230426035757_add_status_to_articles.rb
+++ b/db/migrate/20230426035757_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_230_309_092_232) do
+ActiveRecord::Schema.define(version: 2023_04_26_035757) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,6 +30,7 @@ ActiveRecord::Schema.define(version: 20_230_309_092_232) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -6,5 +6,13 @@ FactoryBot.define do
     title { Faker::Lorem.sentence }
     body { Faker::Lorem.sentence }
     user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -6,6 +6,23 @@ RSpec.describe Article, type: :model do
     let(:article) { build(:article) }
     it "記事が作られる" do
       expect(article).to be_valid
+      expect(article.status).to eq "draft"
+    end
+  end
+
+  context "statusが下書き状態の時" do
+    let(:article) { build(:article, :draft) }
+    it "記事が作られる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "draft"
+    end
+  end
+
+  context "statusが公開状態の時" do
+    let(:article) { build(:article, :published) }
+    it "記事が作られる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "published"
     end
   end
 

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Article", type: :request do
   end
 
   describe "POST /articles/" do
-    subject { post(api_v1_articles_path, params: { article: article_params, status: status_params }, headers:) }
+    subject { post(api_v1_articles_path, params: { article: article_params }, headers:) }
 
     let(:user) { create(:user) }
     let(:article_params) { attributes_for(:article) }
@@ -63,7 +63,6 @@ RSpec.describe "Article", type: :request do
 
     context "ログインユーザーの時、適切なパラメータをもとに記事が作成される" do
       let!(:headers) { user.create_new_auth_token }
-      let(:status_params) { :draft }
       # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_api_v1_user).and_return(user) }
       it "現在のユーザをもとに記事が作成できる" do
         subject
@@ -80,31 +79,8 @@ RSpec.describe "Article", type: :request do
       end
     end
 
-    context "新規作成して、下書きを保存する場合(paramsが(status: draft))" do
-      let!(:headers) { user.create_new_auth_token }
-      let(:status_params) { :draft }
-      # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_api_v1_user).and_return(user) }
-      it "statusがdraftとして保存される" do
-        subject
-        expect(Article.last.status).to eq("draft")
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context "新規作成して、公開記事を保存する場合(paramsが(status: published))" do
-      let!(:headers) { user.create_new_auth_token }
-      let(:status_params) { :published }
-      # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_api_v1_user).and_return(user) }
-      it "statusがpublishedとして保存される" do
-        subject
-        expect(Article.last.status).to eq("published")
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
     # 異常系テスト
     context "tokenを渡していない時、記事が作成されない" do
-      let(:status_params) { :draft }
       it "エラーが起きる" do
         subject
         res = JSON.parse(response.body)
@@ -114,7 +90,6 @@ RSpec.describe "Article", type: :request do
     end
 
     context "token情報が違う時、記事が作成されない" do
-      let(:status_params) { :draft }
       let!(:headers) {
         { "access-token" => "1111",
           "token-type" => "kbndk",

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Article", type: :request do
       it "記事詳細を取得" do
         p(subject)
         res = JSON.parse(response.body)
-        expect(res.keys).to eq ["id", "title", "body", "updated_at", "user"]
+        expect(res.keys).to eq ["id", "title", "body", "updated_at","status" ,"user"]
         expect(res["id"]).to eq article.id
         expect(res["title"]).to eq article.title
         expect(res["body"]).to eq article.body
@@ -108,6 +108,7 @@ RSpec.describe "Article", type: :request do
 
     #異常系テスト
     context "tokenを渡していない時、記事が作成されない" do
+      let(:status_params) { :draft }
       it "エラーが起きる" do
         subject
         res = JSON.parse(response.body)
@@ -117,6 +118,7 @@ RSpec.describe "Article", type: :request do
     end
 
     context "token情報が違う時、記事が作成されない" do
+      let(:status_params) { :draft }
       let!(:headers) {
         { "access-token" => "1111",
           "token-type" => "kbndk",

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Article", type: :request do
       it "記事詳細を取得" do
         p(subject)
         res = JSON.parse(response.body)
-        expect(res.keys).to eq ["id", "title", "body", "updated_at","status" ,"user"]
+        expect(res.keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
         expect(res["id"]).to eq article.id
         expect(res["title"]).to eq article.title
         expect(res["body"]).to eq article.body
@@ -55,7 +55,7 @@ RSpec.describe "Article", type: :request do
   end
 
   describe "POST /articles/" do
-    subject { post(api_v1_articles_path, params: { article: article_params,status: status_params }, headers:) }
+    subject { post(api_v1_articles_path, params: { article: article_params, status: status_params }, headers:) }
 
     let(:user) { create(:user) }
     let(:article_params) { attributes_for(:article) }
@@ -68,7 +68,6 @@ RSpec.describe "Article", type: :request do
       it "現在のユーザをもとに記事が作成できる" do
         subject
         expect(Article.last.user_id).to eq(user.id)
-        binding.pry
         expect(response).to have_http_status(:ok)
       end
 
@@ -85,11 +84,9 @@ RSpec.describe "Article", type: :request do
       let!(:headers) { user.create_new_auth_token }
       let(:status_params) { :draft }
       # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_api_v1_user).and_return(user) }
-      fit "statusがdraftとして保存される" do
-        binding.pry
+      it "statusがdraftとして保存される" do
         subject
         expect(Article.last.status).to eq("draft")
-        binding.pry
         expect(response).to have_http_status(:ok)
       end
     end
@@ -98,15 +95,14 @@ RSpec.describe "Article", type: :request do
       let!(:headers) { user.create_new_auth_token }
       let(:status_params) { :published }
       # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_api_v1_user).and_return(user) }
-      fit "statusがpublishedとして保存される" do
+      it "statusがpublishedとして保存される" do
         subject
         expect(Article.last.status).to eq("published")
-        binding.pry
         expect(response).to have_http_status(:ok)
       end
     end
 
-    #異常系テスト
+    # 異常系テスト
     context "tokenを渡していない時、記事が作成されない" do
       let(:status_params) { :draft }
       it "エラーが起きる" do
@@ -134,8 +130,6 @@ RSpec.describe "Article", type: :request do
         expect(res["errors"][0]).to eq "You need to sign in or sign up before continuing."
       end
     end
-
-
   end
 
   describe "PATCH /articles/:id" do


### PR DESCRIPTION
## 概要: 
下書き、公開機能を実装しました。
## 変更内容: 
・app/models/article.rb
Enumを使用することで、列挙型の値に対応する整数をデータベースに保存できるようにしています。

・app/serializers/api/v1/article_serializer.rb
selializerに返す値としてstatusを追記しています。

・db/migrate/20230426035757_add_status_to_articles.rb
statusカラムを追加する記述をしています。

・spec/factories/articles.rb
traitを使用することで、下書き本番機能をテストしたい時に逐一上書きの記述をしなくて良いようにしています。

・spec/models/article_spec.rb
modelテストでdraftとpublicでデータが保存されるどうかを確かめています。
defaultはdraftです。

・spec/requests/api/v1/articles_spec.rb
返却される想定のkeyにstausを追記しています。