### PR TITLE
自分が書いた下書き記事の一覧と詳細を取得するAPIとテストを実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Articles::DraftsController < ApplicationController
+  def index
+    articles = Article.draft.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+
+  def show
+    article = Article.draft.find(params[:id])
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   # binding.pry
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET /api/v1/articles/drafts/" do
+    subject { get(api_v1_articles_drafts_path) }
+
+    context "記事がdraftの時" do
+      # before { create_list(:article, 3) }
+      let!(:article1) { create(:article, :draft, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, :draft, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article, :draft, title: "一番最初") }
+
+      it "記事の一覧を取得できる" do
+        p(subject)
+        res = JSON.parse(response.body)
+        # res.length = 3
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+        # expect(res.keys).to eq ["id", "account", "name", "created_at", "updated_at", "email"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "記事がpublishedの時" do
+      # before { create_list(:article, 3) }
+      let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, :published, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article, :published, title: "一番最初") }
+
+      it "記事の一覧を取得できない" do
+        p(subject)
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 0
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "GET /api/v1/articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id)) }
+
+    context "指定したidが存在して" do
+      let(:article_id) { article.id }
+      context "下書きであるとき" do
+        let(:article) { create(:article, :draft) }
+        it "記事詳細を取得" do
+          p(subject)
+          res = JSON.parse(response.body)
+          expect(res.keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["updated_at"]).to be_present
+          expect(res["status"]).to eq("draft")
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "記事が公開状態であるとき" do
+        let(:article) { create(:article, :published) }
+
+        it "記事が見つからずエラーが出る" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+
+    context "存在しないidを指定してレコードが見つからない" do
+      let(:article_id) { 100000 }
+      it "記事詳細を取得できない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Article", type: :request do
         # res.length = 3
         expect(res.length).to eq 3
         expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
-        expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
+        expect(res[0].keys).to eq ["id", "title", "body", "updated_at","status", "user"]
         expect(res[0]["user"].keys).to eq ["id", "name", "email"]
         # expect(res.keys).to eq ["id", "account", "name", "created_at", "updated_at", "email"]
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Article", type: :request do
         # res.length = 3
         expect(res.length).to eq 3
         expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
-        expect(res[0].keys).to eq ["id", "title", "body", "updated_at","status", "user"]
+        expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
         expect(res[0]["user"].keys).to eq ["id", "name", "email"]
         # expect(res.keys).to eq ["id", "account", "name", "created_at", "updated_at", "email"]
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Article", type: :request do
         # res.length = 3
         expect(res.length).to eq 3
         expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
-        expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "user"]
+        expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
         expect(res[0]["user"].keys).to eq ["id", "name", "email"]
         # expect(res.keys).to eq ["id", "account", "name", "created_at", "updated_at", "email"]
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
## 概要:
下書き記事はマイページなどで閲覧できる状態にすることが望ましいので、下書き記事一覧と詳細についても取得できるよう実装しました。
## 変更内容: 
⚫︎config/routes.rb
/api/v1/articles/drafts/のルートを作成(index,showのみ)
namespaceとonlyを使い作成しています。

⚫︎gコマンドで以下のコントローラとspecファイルを作成し、articlesをもとにアクションとテストを作成
・app/controllers/api/v1/articles/drafts_controller.rb
・spec/requests/api/v1/articles/drafts_spec.rb

コントローラとスペックファイルともに、articlesで作成していたコントローラと、specファイルをもとに:publishedと:draftを逆に修正して作成しております。


⚫︎app/serializers/api/v1/article_preview_serializer.rb
記事一覧の際のselializerの修正ができていなかったので修正しました。

⚫︎spec/requests/api/v1/articles_spec.rb
selializerの修正に伴い返却されるキーの値にstatusを追加しました。