### PR TITLE
マイページでの自分が書いた公開記事を取得するAPIを作成

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Current::ArticlesController < Api::V1::BaseApiController
+  def index
+    articles = current_api_v1_user.articles.published.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
+      namespace :current do
+        resources :articles, only: [:index]
+      end
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Current::Articles", type: :request do
-
   describe "GET /api/v1/current/articles" do
     subject { get(api_v1_current_articles_path, headers:) }
 

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers:) }
+
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+    context "記事がpublishedの時" do
+      # before { create_list(:article, 3) }
+      let!(:article1) { create(:article, :published, updated_at: 1.days.ago, user:) }
+      let!(:article2) { create(:article, :published, updated_at: 2.days.ago, user:) }
+      let!(:article3) { create(:article, :published, title: "一番最初", user:) }
+      it "記事の一覧を取得できる" do
+        p(subject)
+        res = JSON.parse(response.body)
+        # res.length = 3
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+        # expect(res.keys).to eq ["id", "account", "name", "created_at", "updated_at", "email"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "記事がdraftの時" do
+      # before { create_list(:article, 3) }
+      let!(:article1) { create(:article, :draft, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, :draft, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article, :draft, title: "一番最初") }
+
+      it "記事の一覧を取得できない" do
+        p(subject)
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 0
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
マイページで自分が書いた公開記事を取得するAPIを実装

## 変更内容
⚫︎config/routes.rb
ルーティングの設定(/api/v1/current/articles/)

⚫︎spec/requests/api/v1/current/articles_spec.rb
userを作成後、記事作成時にuserを指定することで同じユーザーが作成したものをテストしています。

user.create_new_auth_tokenを使用し、その作成したユーザーでログインした状態でテストを行っています。

⚫︎app/controllers/api/v1/current/articles_controller.rb
Api::V1::BaseApiControllerから継承しているのもポイント。
devise_token_authを利用できるようにしているコントローラから継承。

specファイルとコントローラファイルの作成はgコマンドで行なっています。
`rails generate controller api/v1/current/articles index --no-help… 
…er --no-asset`